### PR TITLE
Only create a wav if there is text to process

### DIFF
--- a/radio.py
+++ b/radio.py
@@ -819,11 +819,12 @@ class Dialogue:
         """
         if not hasattr(self, "synthesizer"):
             self.synthesizer = self.init_speech()
-        wavs = self.synthesizer.tts(
-            text, speaker_name=TTS["speaker_name"], style_wav=""
-        )
-        self.synthesizer.save_wav(wavs, f"{self.audio_dir}/a{self.index}.wav")
-        self.index += 1
+        if text:
+            wavs = self.synthesizer.tts(
+                text, speaker_name=TTS["speaker_name"], style_wav=""
+            )
+            self.synthesizer.save_wav(wavs, f"{self.audio_dir}/a{self.index}.wav")
+            self.index += 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit of a single `if` appears to ameliorate this error that happens often for me, on a fresh clone:

Traceback (most recent call last):
  File "radio.py", line 831, in <module>
    dialogue.flow()
  File "radio.py", line 613, in flow
    self.speak(speech)
  File "radio.py", line 742, in speak
    self.save_speech(say)
  File "radio.py", line 822, in save_speech
    wavs = self.synthesizer.tts(
  File "/home/gene/.local/lib/python3.8/site-packages/TTS/utils/synthesizer.py", line 242, in tts
    raise ValueError(
ValueError: You need to define either `text` (for sythesis) or a `reference_wav` (for voice conversion) to use the Coqui TTS API.